### PR TITLE
fix opus_express shuffle broken due to missing import

### DIFF
--- a/opustools_pkg/bin/opus_express
+++ b/opustools_pkg/bin/opus_express
@@ -9,7 +9,7 @@ import json
 import tempfile
 
 from opustools import OpusRead
-from random import randint
+from random import randint, shuffle
 from xml.parsers.expat import ExpatError
 
 with urllib.request.urlopen('http://opus.nlpl.eu/opusapi/?corpora=True') as url:


### PR DESCRIPTION
Found that an import of `random.shuffle` was missing from `opustools_pkg/bin/opus_express` that causes NameErrors at line 179 when `opus_express` is called with the `--shuffle` option.