### PR TITLE
fix ZeroDivisionError bug in progress printing

### DIFF
--- a/opustools_pkg/opustools/parse/block_parser.py
+++ b/opustools_pkg/opustools/parse/block_parser.py
@@ -105,7 +105,7 @@ class BlockParser:
         for line in self.document:
             if verbose:
                 if cur_pos%10000 == 0 or cur_pos == self.doc_size:
-                    progress = str(round(cur_pos/self.doc_size*100, 2))
+                    progress = str(round(cur_pos/self.doc_size*100, 2) if self.doc_size > 0 else 0)
                     print("\x1b[2KParsing file \"{}\" ... {}%".format(self.document.name,
                         progress), end="\r")
             cur_pos += len(line)
@@ -114,7 +114,7 @@ class BlockParser:
                 ret_blocks = self.completeBlocks
                 self.completeBlocks = []
                 return ret_blocks, cur_pos
-        progress = str(round(cur_pos/self.doc_size*100, 2))
+        progress = str(round(cur_pos/self.doc_size*100, 2) if self.doc_size > 0 else 0)
         if verbose:
             print("\x1b[2KParsing file \"{}\" ... {}%".format(self.document.name,
                 progress), end="\r")


### PR DESCRIPTION
Progress prints may raise ZeroDivisionError. Example:
```
Parsing file "/projappl/nlpl/data/OPUS/QED/latest/xml/en-fi.xml.gz" ... 0.0%
Parsing file "QED/raw/en/5OpKSniHEzM1.xml" ... 100.0%
Traceback (most recent call last):ggu.xml" ... 100.0%
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/bin/opusfilter", line 31, in <module>
    of.execute_steps(overwrite=args.overwrite, last=args.last)
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/lib/python3.8/site-packages/opusfilter/opusfilter.py", line 227, in execute_steps
    self._run_step(step, num + 1, overwrite)
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/lib/python3.8/site-packages/opusfilter/opusfilter.py", line 292, in _run_step
    self.step_functions[step['type']](parameters, overwrite=overwrite)
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/lib/python3.8/site-packages/opusfilter/opusfilter.py", line 340, in read_from_opus
    opus_reader.printPairs()
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/lib/python3.8/site-packages/opustools/opus_read.py", line 244, in printPairs
    trg_parser.store_sentences(trg_set, self.verbose)
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/lib/python3.8/site-packages/opustools/parse/sentence_parser.py", line 153, in store_sentences
    blocks, cur_pos = bp.get_complete_blocks(cur_pos, verbose)
  File "/projappl/nlpl/software/modules/opusfilter/2.5.1/lib/python3.8/site-packages/opustools/parse/block_parser.py", line 117, in get_complete_blocks
    progress = str(round(cur_pos/self.doc_size*100, 2))
ZeroDivisionError: division by zero
```